### PR TITLE
Change the handling of CA certs

### DIFF
--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/README.md
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/README.md
@@ -200,10 +200,15 @@ mkdir -p /opt/ibm/icic
 scp user@host:/opt/ibm/icic/icicrc /opt/ibm/icic/
 ```
 
-5. Copy the `icic.crt` file from the IBM Cloud Infrastructure Center management node to your certs directory `/etc/pki/tls/certs/`:
+5 A. Copy the `icic.crt` file from the IBM Cloud Infrastructure Center management node to your certs directory `/etc/pki/tls/certs/`:
 ```
 scp user@host:/etc/pki/tls/certs/icic.crt /etc/pki/tls/certs/
 ```
+
+  B. Copy your root CA cert for ocp to the root directory of this repo in `ocp.crt`. Add a line to your `icicrc` 
+    ```
+    export OCP_CACERT=$HOME/<path>/<to>/ocp.crt
+    ```
 
 6. Run the source `icicrc` to set the environment variables:
 ```

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/inventory.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/inventory.yaml
@@ -70,36 +70,9 @@ all:
       localreg_source2: "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
       localreg_media: "http://fpetutil.fpet.pokprv.stglabs.ibm.com/lzocpc"
 
-      additional_certs: |
-        additionalTrustBundle: |
-          -----BEGIN CERTIFICATE-----
-          MIIEuzCCAyOgAwIBAgIBATANBgkqhkiG9w0BAQsFADBGMSQwIgYDVQQKDBtGUEVU
-          LlBPS1BSVi5TVEdMQUJTLklCTS5DT00xHjAcBgNVBAMMFUNlcnRpZmljYXRlIEF1
-          dGhvcml0eTAeFw0yMTA4MTYxNTA2MjJaFw00MTA4MTYxNTA2MjJaMEYxJDAiBgNV
-          BAoMG0ZQRVQuUE9LUFJWLlNUR0xBQlMuSUJNLkNPTTEeMBwGA1UEAwwVQ2VydGlm
-          aWNhdGUgQXV0aG9yaXR5MIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEA
-          58r05eSLyAlHWu2mMtXUPRareADrIKfumz6O9YSrcxXXXs21P5YsIVMMi79v9DOi
-          LWyVdIQ5sX8ABSkIFmvyR0+uryd7zOlFuZJ34eIyQ8hJJVcmIJw+3n8x8sa0HbZ8
-          ao3OZz3YrM1svAey4XBINl9won50lrx8asbRC29EJtPE6URrB4qO6Fenx9IZ67nW
-          GC8KeXSTliX161PS7JNDcQOb5obtIP7SGjsCVL5xXVfrSPzcc6Kbg1soErpVTJ1u
-          ZqI5Bg35duVUdq8nyFNcpPZ0bJcIyT7eN11oh50/gzDc7bgnp2RJJosPl+FDEEXZ
-          44QxnioHOiRIngUkCM7dDgrPjdq2PCTiw+YykmR6KThdm0bnZ81Nyso/9CEnWZqU
-          DYpbSnO6Gkz/aTdxAZ9b0jKxlsDuPRH0yHUuNCsecUadeOazQyHvr3mecaOCxc2E
-          vPLrj8T01n6Un5n1K3AgZ9Qtp3DzxvQmhkBLe183V870FMYnzoVE2R5p9Tanztqb
-          AgMBAAGjgbMwgbAwHwYDVR0jBBgwFoAUWl1Gycb6XU6QdKILW25GCvvciRAwDwYD
-          VR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAcYwHQYDVR0OBBYEFFpdRsnG+l1O
-          kHSiC1tuRgr73IkQME0GCCsGAQUFBwEBBEEwPzA9BggrBgEFBQcwAYYxaHR0cDov
-          L2lwYS1jYS5mcGV0LnBva3Bydi5zdGdsYWJzLmlibS5jb20vY2Evb2NzcDANBgkq
-          hkiG9w0BAQsFAAOCAYEA545ByUeL8jtRnfGrqQQJuRE/+exUe+/e4sWzASHC6Z/z
-          y0rjcM5dMdNYTGiy2lidF4lcBV0mTc28ubO0vZ68MzH4uYT4KObsC0e4xxKO2EH6
-          6RL6oJ9f2zKpOu28fcyKRjA74OLb+69354Qpr8TmQhkWRb7tE9hj1OQHrj+uJG+l
-          CQzvAKxDBYWqDwAkWhsBXi/EBesCkCXoJDlyE9my8eAndUOLRNDqlFZJPDuasJrZ
-          EdQJie9exU+CU1+Hm0oQH3HWsfvSgg/vAUk9MXrTxets0eVY22G5kZKSZvSnN9A7
-          oL8PNCuq3BZleSNxgeovoBp3mIMrFfwHIRwu8EL3CeFecV6wOaZrFBRU938mLwVa
-          RPPm1I4wxEnqSn9yqLkBiFGbb0o5ELfGMv2zHGiR+wHGYbelbS2ewCLgo/+w690E
-          rtlwkB3+yU4Qwld+BiRSb84CvGufVSeZ2abPk7Kf67fLRfKtIHza4hzJwpo6z4wq
-          bRaUkgKe6w4n+XYm7WGg
-          -----END CERTIFICATE-----
+      # ocp.crt is the cert that you wish to use as the CA insisde OCP
+      # should match the OCP_CACERT env var in your icicrc
+      additional_certs: "{{ lookup('file', '/<path>/<to>/ocp.crt') | indent (width=2) }}"
 
       approve_nodes_csr: 15 # minute
       create_server_timeout: 15 # minute

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/tools/generate-bootstrap-ignitionshim.py
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/tools/generate-bootstrap-ignitionshim.py
@@ -46,11 +46,17 @@ bootstrap_ign_shim = {
     }
   }
 
-ca_cert_path = os.environ.get('OS_CACERT', '')
-if ca_cert_path:
-    with open(ca_cert_path, 'r') as f:
-        ca_cert = f.read().encode()
-        ca_cert_b64 = base64.standard_b64encode(ca_cert).decode().strip()
+#this will be the cert for the CIC instance
+os_ca_cert_path = os.environ.get('OS_CACERT', '')
+#this will be the CA cert used by OCP
+ocp_ca_cert_path = os.environ.get('OCP_CACERT', '')
+if os_ca_cert_path and ocp_ca_cert_path:
+    with open(os_ca_cert_path, 'r') as f:
+        cic_ca_cert = f.read().encode()
+        cic_ca_cert_b64 = base64.standard_b64encode(cic_ca_cert).decode().strip()
+    with open(ocp_ca_cert_path, 'r') as f:
+        ocp_ca_cert = f.read().encode()
+        ocp_ca_cert_b64 = base64.standard_b64encode(ocp_ca_cert).decode().strip()
     files = bootstrap_ign_shim['ignition']
     files.update(
     {
@@ -58,7 +64,10 @@ if ca_cert_path:
         "tls": {
           "certificateAuthorities": [
             {
-              "source": "data:text/plain;charset=utf-8;base64," + ca_cert_b64,
+              "source": "data:text/plain;charset=utf-8;base64," + cic_ca_cert_b64,
+            },
+            {
+              "source": "data:text/plain;charset=utf-8;base64," + ocp_ca_cert_b64,
             }
           ]
         }


### PR DESCRIPTION
The changes here are required when IBM CIC has a different root CA cert and thus chain from the root CA cert that you would like to use in OCP